### PR TITLE
Update to Kotlin 1.9.10 and AGP 8.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://user-images.githubusercontent.com/5982196/202266973-6cec2e9e-627d-4a97-a664-eef04d1e07d3.png" width="600" />
   <p><br />This repository is the stable base upon which we build our Kotlin Multiplatform projects at Mirego.<br />We want to share it with the world so you can build awesome multiplatform applications too.</p>
   <a href="https://github.com/mirego/kmp-boilerplate/actions/workflows/ci.yml"><img src="https://github.com/mirego/kmp-boilerplate/actions/workflows/ci.yaml/badge.svg"/></a>
-  <a href="https://kotlinlang.org/"><img src="https://img.shields.io/badge/kotlin-1.8.21-blue.svg?logo=kotlin"/></a>
+  <a href="https://kotlinlang.org/"><img src="https://img.shields.io/badge/kotlin-1.9.10-blue.svg?logo=kotlin"/></a>
   <a href="https://opensource.org/licenses/BSD-3-Clause"><img src="https://img.shields.io/badge/License-BSD_3--Clause-blue.svg"/></a>
 </div>
 
@@ -16,7 +16,7 @@ our [blog post](https://shift.mirego.com/en/boilerplate-projects).
 This boilerplate comes with batteries included, you’ll find:
 
 - A brand new [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html) project using
-  [Kotlin 1.8.21](https://kotlinlang.org/docs/whatsnew1820.html) and
+  [Kotlin 1.9.10](https://github.com/JetBrains/kotlin/releases/tag/v1.9.10) and
   the [Cocoapods Plugin](https://kotlinlang.org/docs/native-cocoapods.html)
 - An Android app using [Jetpack Compose](https://developer.android.com/jetpack/compose)
 - An iOS app using [SwiftUI](https://developer.apple.com/xcode/swiftui)
@@ -28,7 +28,9 @@ This boilerplate comes with batteries included, you’ll find:
 - Opinionated Swift linting with [SwiftLint](https://github.com/realm/SwiftLint)
 - A [CI workflow](.github/workflows/ci.yaml)
   using [GitHub actions](https://docs.github.com/en/actions)
-- Translations with [Trikot.KWord](https://github.com/mirego/trikot/tree/master/trikot-kword) and [Accent](https://www.accent.reviews) (using a scheduled GitHub Actions [workflow](./.github/workflows/accent.yaml))
+- Translations with [Trikot.KWord](https://github.com/mirego/trikot/tree/master/trikot-kword)
+  and [Accent](https://www.accent.reviews) (using a scheduled GitHub
+  Actions [workflow](./.github/workflows/accent.yaml))
 - A clean and useful `README.md` template (in [english](./BOILERPLATE_README.md))
 
 ## Usage
@@ -70,7 +72,7 @@ have their own needs and requirements. Here’s a list of our preferred librarie
 started:
 
 | Category                 | Libraries                                                                                                               |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+|--------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | HTTP networking          | [`ktor`](https://ktor.io/)                                                                                              |
 | GraphQL client           | [`apollo-kotlin`](https://www.apollographql.com/docs/kotlin/)                                                           |
 | Persisted preferences    | [`multiplatform-setttings`](https://github.com/russhwolf/multiplatform-settings)                                        |
@@ -81,7 +83,7 @@ started:
 
 ## License
 
-Kmp Boilerplate is © 2022 [Mirego](https://www.mirego.com) and may be freely distributed under
+Kmp Boilerplate is © 2023 [Mirego](https://www.mirego.com) and may be freely distributed under
 the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See
 the [`LICENSE.md`](https://github.com/mirego/kmp-boilerplate/blob/master/LICENSE.md) file.
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,16 +1,14 @@
-@file:Suppress("UnstableApiUsage")
-
 plugins {
-    id("com.android.application")
-    kotlin("android")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
 }
 
 android {
     namespace = "com.mirego.kmp.boilerplate"
-    compileSdk = 33
+    compileSdk = 34
     defaultConfig {
         minSdk = 21
-        targetSdk = 33
+        targetSdk = 34
 
         applicationId = "com.mirego.kmp.boilerplate"
         versionCode = 1
@@ -37,7 +35,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.7"
+        kotlinCompilerExtensionVersion = libs.versions.androidComposeCompiler.get()
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
+    alias(libs.plugins.kotlin.native.cocoapods) apply false
     alias(libs.plugins.serialization) apply false
     alias(libs.plugins.ktlint) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,13 @@
 [versions]
-androidGradlePlugin = "8.0.2"
+androidComposeCompiler = "1.5.3"
+androidGradlePlugin = "8.1.1"
 androidxActivityCompose = "1.7.2"
 androidxAppcompat = "1.6.1"
-androidxComposeBom = "2023.05.01"
-kotlin = "1.8.21"
-kotlinxCoroutines = "1.7.1"
-kotlinxSerializationJson = "1.5.1"
-ktlint = "11.4.0"
+androidxComposeBom = "2023.08.00"
+kotlin = "1.9.10"
+kotlinxCoroutines = "1.7.3"
+kotlinxSerialization = "1.6.0"
+ktlint = "11.5.1"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivityCompose" }
@@ -17,13 +18,14 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-material = { group = "androidx.compose.material", name = "material" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlin-native-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 16 18:04:19 EST 2021
+#Thu Aug 31 10:40:08 EDT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,20 +1,16 @@
-@file:Suppress("UNUSED_VARIABLE")
-
-import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest
-
 plugins {
-    kotlin("multiplatform")
-    kotlin("native.cocoapods")
-    kotlin("plugin.serialization")
-    id("com.android.library")
-    id("org.jlleitschuh.gradle.ktlint")
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.native.cocoapods)
+    alias(libs.plugins.serialization)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.ktlint)
 }
 
 version = "0.1"
 
 kotlin {
     jvmToolchain(17)
-    android {
+    androidTarget {
         publishAllLibraryVariants()
     }
     ios()
@@ -75,7 +71,7 @@ android {
     namespace = "com.mirego.kmp.boilerplate.common"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
 
-    compileSdk = 33
+    compileSdk = 34
     defaultConfig {
         minSdk = 21
     }
@@ -92,11 +88,4 @@ ktlint {
     filter {
         exclude { element -> element.file.path.contains("generated/") }
     }
-}
-
-// Make sure iOS simulator tests are ran on an available device (defaults to iPhone 14).
-// Run `/usr/bin/xcrun simctl list devices available` to list the available devices on your machine
-// See https://slack-chats.kotlinlang.org/t/535280/i-have-the-same-issue-leaving-a-comment-to-track
-tasks.filterIsInstance<KotlinNativeSimulatorTest>().forEach { task ->
-    task.device.set(properties["iosSimulatorName"] as? String ?: "iPhone 14")
 }


### PR DESCRIPTION
Also,
- Bump Android compileSDK and targetSDK from 33 to 34
- Update libs to their latest
- Cleanup now deprecated configurations