### PR TITLE
Fix boilerplate setup script replacing false positives

### DIFF
--- a/boilerplate-setup.sh
+++ b/boilerplate-setup.sh
@@ -19,6 +19,7 @@ content=$(find . -type f \( \
   -name "*.plist" -or \
   -name "*.pbxproj" \
 \) \
+  -and ! -path "./build/*" \
   -and ! -path "./boilerplate-setup.sh" \
   -and ! -path "./.idea/*" \
   -and ! -path "./.git/*" \
@@ -95,7 +96,9 @@ success "Done!\n"
 header "Updating iOS Framework name..."
 frameworkName="Shared"
 for file in $content; do
-  run "/usr/bin/sed -i .bak s/$frameworkName/$FRAMEWORK_NAME/g $file"
+  if [[ $file != *.kt ]]; then
+    run "/usr/bin/sed -i .bak s/$frameworkName/$FRAMEWORK_NAME/g $file"
+  fi
 done
 mv shared/"${frameworkName}".podspec shared/"${FRAMEWORK_NAME}".podspec
 success "Done!\n"


### PR DESCRIPTION
When running `boilerplate-setup.sh`, we now ignore kotlin files when replacing the iOS Framework name to avoid replacing occurrences of the "Shared" keyword (such as `kotlinx.coroutines.SharedFlow` for example). 

We also ignore generated files in `build` directories to speed things up. 🚀 